### PR TITLE
FPS-131: Format 'using the API to draft loans' page

### DIFF
--- a/portal/docs/overview/draftloans.md
+++ b/portal/docs/overview/draftloans.md
@@ -23,7 +23,7 @@ It is fine if the API sends information for some but not all fields required to 
 
 Depending on if you are posting a group or individual loan, certain fields are not required. If the loan you are posting is an individual loan, and you send data that is specific to a group loan, PA2 will give you an error message and you will be unable to publish the loan.
 
-If posting an individual loan, do not include any of the following fields. The following fields are required **only when posting a group loan**:
+If posting an individual loan, do not include any of the following fields. **The following fields are required only when posting a group loan:**
 
 * `group_name`: this is the name of the group that will appear on Kiva.org.
 * `internal_client_id`: this is the ID of each client represented within the group (for example, if a group has three members, each member might have their own client ID that should be listed here)

--- a/portal/docs/overview/draftloans.md
+++ b/portal/docs/overview/draftloans.md
@@ -6,11 +6,12 @@ sidebar_position: 3
 
 We recommend that your technical team consults with the Kiva Coordinator at your organization to fully understand Kiva's Repayment Reporting process. To do so, please have your technical team review the following:
 
-* This [video](https://www.youtube.com/watch?v=9gScexv-yZo&amp;t=5s) provides a thorough explanation on how to post an individual loan
-* This [video](https://www.youtube.com/watch?v=KvKUScWF73M&amp;t=1s) provides a thorough explanation on how to post a group loan.
+* [This video](https://www.youtube.com/watch?v=9gScexv-yZo&amp;t=5s) provides a thorough explanation on how to post an individual loan
+* [This video](https://www.youtube.com/watch?v=KvKUScWF73M&amp;t=1s) provides a thorough explanation on how to post a group loan
+* Visit the New Loans section for more information, specifically [Step 1: Description - Individual Loans](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360030919632) and [Step 1: Description - Group Loans](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360031260191)
 
-Step 1: Description - Individual Loans and Step 1: Description - Group Loans
-Process
+### Process
+
 Information for a new loan is sent from MIS to PA2 via the API
 A draft profile is automatically created. Drafts can be viewed by clicking the “Drafts” link in the “Loans” box on the PA2 homepage.
 Each draft must be reviewed and then published by a person.
@@ -19,24 +20,22 @@ Each draft must be reviewed and then published by a person.
 Before the loan can be published, PA2 will run all of the same validation checks that it runs on loans posted without the API. All error messages will need to be resolved before the loan can be published.
 
 It is fine if the API sends information for some but not all fields required to post a loan. For example, not all MIS's store Kiva-specific fields such as the borrower description or sector. While these fields are required to publish a loan on PA2, they are not required to be sent via the API. The information for these fields can be added manually after the draft loan has been created in PA2. Note that the more information you can send via the API, the more time savings the Kiva Coordinator will have.
+
 Depending on if you are posting a group or individual loan, certain fields are not required. If the loan you are posting is an individual loan, and you send data that is specific to a group loan, PA2 will give you an error message and you will be unable to publish the loan.
 
-If posting an individual loan, do not include any of the following fields. The following fields are required only when posting a group loan:
+If posting an individual loan, do not include any of the following fields. The following fields are required **only when posting a group loan**:
 
-**Group_name**: this is the name of the group that will appear on Kiva.org.
+* `group_name`: this is the name of the group that will appear on Kiva.org.
+* `internal_client_id`: this is the ID of each client represented within the group (for example, if a group has three members, each member might have their own client ID that should be listed here)
+* `internal_loan_id`: this is the ID for each individual borrower's loan (for example, a member of the group might be taking out their third loan with the organization, and that loan might have a unique ID. Enter that ID here)
+* `not_pictured`: use this field in case any borrower is listed in Step 1: Description does not appear in the photo
 
-**Internal_client_id**: this is the ID of each client represented within the group (for example, if a group has three members, each member might have their own client ID that should be listed here)
-
-**Internal_loan_id**: this is the ID for each individual borrower's loan (for example, a member of the group might be taking out their third loan with the organization, and that loan might have a unique ID. Enter that ID here)
-
-**Not_pictured**: use this field in case any borrower is listed in Step 1: Description does not appear in the photo
-
-The borrower photo can be sent to PA2 as a URL. Repayment Schedules can be sent in several different formats. If you believe a format different from the one in the example below will work better for your organization, please let Kiva know and we will provide more information.
+The borrower photo can be sent to PA2 as a base-64 encoded image. Repayment Schedules can be sent in several different formats. If you believe a format different from the one in the example below will work better for your organization, please let Kiva know and we will provide more information.
 
 ## Validation
 To check if the JSON document you created is correct, you can use an online JSON validator like this one:  https://jsonlint.com/.
 
 ## Technical documentation
 All of Kiva's technical documentation, including endpoints, can be found here:
-Test environment (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
-Production (to use after testing): https://partner-api.k1.kiva.org/swagger-ui/
+* Test environment (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
+* Production (to use after testing): https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/draftloans.md
+++ b/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/draftloans.md
@@ -5,11 +5,9 @@ sidebar_position: 3
 # Uso de la API para publicar borradores de préstamos
 
 Recomendamos que su equipo técnico consulte con el coordinador de Kiva de su organización para comprender plenamente el proceso de publicación de borradores de préstamos de Kiva. Para ello, pida a su equipo técnico que revise lo siguiente:
-
-* En este [vídeo](https://www.youtube.com/watch?v=9gScexv-yZo&amp;t=5s) se explica detalladamente cómo publicar un préstamo individual
-* En este [vídeo](https://www.youtube.com/watch?v=KvKUScWF73M&amp;t=1s) ofrece una explicación detallada sobre cómo publicar un préstamo grupal.
-* Visite la sección de Nuevos Préstamos para obtener más información, concretamente el Paso 1: Descripción - Préstamos individuales y el Paso 1: Descripción - Préstamos grupales
-
+* En [este vídeo](https://www.youtube.com/watch?v=9gScexv-yZo&amp;t=5s) se explica detalladamente cómo publicar un préstamo individual
+* En [este vídeo](https://www.youtube.com/watch?v=KvKUScWF73M&amp;t=1s) ofrece una explicación detallada sobre cómo publicar un préstamo grupal
+* Visite la sección de Nuevos Préstamos para obtener más información, concretamente el [Paso 1: Descripción - Préstamos individuales](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360030919632) y el [Paso 1: Descripción - Préstamos grupales](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360031260191)
 
 ## Proceso
 
@@ -19,19 +17,22 @@ Recomendamos que su equipo técnico consulte con el coordinador de Kiva de su or
 
 ### Información adicional
 
-* Antes de que el préstamo sea publicado, PA2 ejecutará todas las mismas revisiones de validación que ejecuta en los préstamos publicados sin la API. Todos los mensajes de error deberán ser resueltos antes de que el préstamo pueda ser publicado.
-* Está bien que la API no envíe información de algunos campos necesarios para publicar un préstamo. Por ejemplo, no todos los SIGs almacenan campos específicos de Kiva como la descripción del prestatario o el sector. Aunque estos campos son necesarios para publicar un préstamo en PA2, no es necesario que se envíen a través de la API. La información para estos campos puede ser añadida manualmente después de que el borrador del préstamo haya sido creado en PA2. Tenga en cuenta que cuanta más información pueda enviar a través de la API, más tiempo ahorrará el coordinador de Kiva.
-* Dependiendo de si está publicando un préstamo de grupo o individual, algunos campos no son necesarios. Si el préstamo que está publicando es un préstamo individual, y envía datos que son específicos de un préstamo de grupo, PA2 le dará un mensaje de error y no podrá publicar el préstamo.
-* Si se publica un préstamo individual, no se debe incluir ninguno de los siguientes campos. Los siguientes campos sólo son necesarios cuando se contabiliza un préstamo grupal:
-  * Group_name: este es el nombre del grupo que aparecerá en Kiva.org.
-  * Internal_client_id: es el ID de cada cliente representado dentro del grupo (por ejemplo, si un grupo tiene tres miembros, cada uno de ellos puede tener su propio ID de cliente que debe figurar aquí)
-  * Internal_loan_id: este es el ID de cada préstamo individual (por ejemplo, un miembro del grupo podría estar tomando su tercer préstamo con la organización, y ese préstamo podría tener un ID único. Introduzca ese ID aquí)
-  * Not_pictured: utilice este campo en caso de que algún prestatario figure en el Paso 1: La descripción no aparece en la foto
-* La foto del prestatario puede ser enviada a PA2 a través de la API.
-* Los calendarios de reembolso pueden enviarse en varios formatos diferentes. Si cree que un formato diferente al del ejemplo siguiente funcionará mejor para su organización, comuníquelo a Kiva y le proporcionaremos más información.
-* Para comprobar si el documento JSON que has creado es correcto, puedes utilizar un validador de JSON online como este: https://jsonlint.com/ .
+Antes de que el préstamo sea publicado, PA2 ejecutará todas las mismas revisiones de validación que ejecuta en los préstamos publicados sin la API. Todos los mensajes de error deberán ser resueltos antes de que el préstamo pueda ser publicado.
+ 
+Está bien que la API no envíe información de algunos campos necesarios para publicar un préstamo. Por ejemplo, no todos los SIGs almacenan campos específicos de Kiva como la descripción del prestatario o el sector. Aunque estos campos son necesarios para publicar un préstamo en PA2, no es necesario que se envíen a través de la API. La información para estos campos puede ser añadida manualmente después de que el borrador del préstamo haya sido creado en PA2. Tenga en cuenta que cuanta más información pueda enviar a través de la API, más tiempo ahorrará el coordinador de Kiva.
+
+Dependiendo de si está publicando un préstamo de grupo o individual, algunos campos no son necesarios. Si el préstamo que está publicando es un préstamo individual, y envía datos que son específicos de un préstamo de grupo, PA2 le dará un mensaje de error y no podrá publicar el préstamo.
+
+Si se publica un préstamo individual, no se debe incluir ninguno de los siguientes campos. **Los siguientes campos sólo son necesarios cuando se contabiliza un préstamo grupal**:
+
+* `group_name`: este es el nombre del grupo que aparecerá en Kiva.org.
+* `internal_client_id`: es el ID de cada cliente representado dentro del grupo (por ejemplo, si un grupo tiene tres miembros, cada uno de ellos puede tener su propio ID de cliente que debe figurar aquí)
+* `internal_loan_id`: este es el ID de cada préstamo individual (por ejemplo, un miembro del grupo podría estar tomando su tercer préstamo con la organización, y ese préstamo podría tener un ID único. Introduzca ese ID aquí)
+* `not_pictured`: utilice este campo en caso de que algún prestatario figure en el Paso 1: La descripción no aparece en la foto
+ 
+La foto del prestatario puede ser enviada a PA2 a través de la API. Los calendarios de reembolso pueden enviarse en varios formatos diferentes. Si cree que un formato diferente al del ejemplo siguiente funcionará mejor para su organización, comuníquelo a Kiva y le proporcionaremos más información. Para comprobar si el documento JSON que has creado es correcto, puedes utilizar un validador de JSON online como este: https://jsonlint.com/.
 
 ## Documentación técnica
-* Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
-  * Entorno de pruebas (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
-  * Producción (para usar después de las pruebas):https://partner-api.k1.kiva.org/swagger-ui/
+Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
+* Entorno de pruebas (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
+* Producción (para usar después de las pruebas):https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/draftloans.md
+++ b/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/draftloans.md
@@ -23,7 +23,7 @@ Está bien que la API no envíe información de algunos campos necesarios para p
 
 Dependiendo de si está publicando un préstamo de grupo o individual, algunos campos no son necesarios. Si el préstamo que está publicando es un préstamo individual, y envía datos que son específicos de un préstamo de grupo, PA2 le dará un mensaje de error y no podrá publicar el préstamo.
 
-Si se publica un préstamo individual, no se debe incluir ninguno de los siguientes campos. **Los siguientes campos sólo son necesarios cuando se contabiliza un préstamo grupal**:
+Si se publica un préstamo individual, no se debe incluir ninguno de los siguientes campos. **Los siguientes campos sólo son necesarios cuando se contabiliza un préstamo grupal:**
 
 * `group_name`: este es el nombre del grupo que aparecerá en Kiva.org.
 * `internal_client_id`: es el ID de cada cliente representado dentro del grupo (por ejemplo, si un grupo tiene tres miembros, cada uno de ellos puede tener su propio ID de cliente que debe figurar aquí)

--- a/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/draftloans.md
+++ b/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/draftloans.md
@@ -20,7 +20,7 @@ Il n'y a pas de problème si l'API n'envoie pas d'informations pour certains cha
 
 Lorsque vous publiez un prêt collectif ou individuel, certains champs ne sont pas obligatoires. Si le prêt que vous publiez est un prêt individuel, et que vous soumettez des données spécifiques à un prêt collectif, PA2 vous donnera un message d'erreur et vous ne pourrez pas publier le prêt.
 
-Si un prêt individuel est comptabilisé, aucune des zones suivantes ne doit être incluse. Les champs suivants sont uniquement requis lors de la publication d'un prêt de groupe :
+Si un prêt individuel est comptabilisé, aucune des zones suivantes ne doit être incluse. **Les champs suivants sont uniquement requis lors de la publication d'un prêt de groupe :**
 * `group_name`: il s'agit du nom du groupe qui apparaîtra sur Kiva.org.
 * `internal_client_id`: est l'ID de chaque client représenté dans le groupe (par exemple, si un groupe compte trois membres, chacun d'entre eux peut avoir son propre ID de client à énumérer ici).
 * `internal_loan_id`: il s'agit de l'ID de chaque prêt individuel (par exemple, un membre du groupe pourrait obtenir son troisième prêt auprès de l'organisation, et ce prêt pourrait avoir un ID unique). Entrez ce numéro d'identification ici)

--- a/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/draftloans.md
+++ b/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/draftloans.md
@@ -3,31 +3,32 @@ sidebar_position: 3
 ---
 
 # Utilisation de l'API pour publier des projets de prêts
-Nous recommandons à votre équipe technique de consulter le coordinateur Kiva de votre organisation afin de bien comprendre le processus de publication des projets de prêts Kiva. Pour ce faire, demandez à votre équipe technique d'examiner les points suivants :
-* Cette vidéo explique en détail comment publier un prêt individuel.
-* Cette vidéo explique en détail comment publier un prêt de groupe.
-* Consultez la section Nouveaux prêts pour plus d'informations, en particulier l'étape 1 : Description - Prêts individuels et l'étape 1 : Description - Prêts de groupe.
-
+Nous recommandons à votre équipe technique de consulter le coordinateur Kiva de votre organisation afin de bien comprendre le processus de publication des projets de prêts Kiva. Pour ce faire, demandez à votre équipe technique d'examiner les points suivants:
+* [Cette vidéo](https://www.youtube.com/watch?v=9gScexv-yZo&amp;t=5s) explique en détail comment publier un prêt individuel.
+* [Cette vidéo](https://www.youtube.com/watch?v=KvKUScWF73M&amp;t=1s) explique en détail comment publier un prêt de groupe.
+* Consultez la section Nouveaux prêts pour plus d'informations, en particulier [l'étape 1 : Description - Prêts individuels](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360030919632) et [l'étape 1 : Description - Prêts de groupe](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360031260191).
+ 
 ## Processus
 * Les nouvelles informations sur les prêts sont envoyées du SIG à PA2 via l'API.
 * Un projet de prêt est automatiquement créé. Les projets peuvent être consultés en cliquant sur le lien " Brouillons " dans la section " Prêts " de la page d'accueil de PA2.
 * Utilisation du point de terminaison de récupération des prêts de l'API.
 
 ## Informations complémentaires
-* Avant que le prêt en question ne soit publié, PA2 effectuera tous les mêmes contrôles de validation que pour les prêts publiés sans l'API. Tous les messages d'erreur doivent être résolus avant que le prêt puisse être publié.
-* Il n'y a pas de problème si l'API n'envoie pas d'informations pour certains champs nécessaires à la publication d'un prêt. Par exemple, tous les SIG ne stockent pas les champs spécifiques de Kiva tels que la description de l'emprunteur ou le secteur. Bien que ces champs soient nécessaires pour publier un prêt dans PA2, ils ne doivent pas être envoyés via l'API. Les informations relatives à ces champs peuvent être ajoutées manuellement après que le projet de prêt a été créé dans PA2. Notez que plus vous pouvez envoyer d'informations via l'API, plus le coordinateur Kiva gagnera du temps.
-* Lorsque vous publiez un prêt collectif ou individuel, certains champs ne sont pas obligatoires. Si le prêt que vous publiez est un prêt individuel, et que vous soumettez des données spécifiques à un prêt collectif, PA2 vous donnera un message d'erreur et vous ne pourrez pas publier le prêt.
-* Si un prêt individuel est comptabilisé, aucune des zones suivantes ne doit être incluse. Les champs suivants sont uniquement requis lors de la publication d'un prêt de groupe :
-  * Group_name: il s'agit du nom du groupe qui apparaîtra sur Kiva.org.
-  * Internal_client_id: est l'ID de chaque client représenté dans le groupe (par exemple, si un groupe compte trois membres, chacun d'entre eux peut avoir son propre ID de client à énumérer ici).
-  * Internal_loan_id: il s'agit de l'ID de chaque prêt individuel (par exemple, un membre du groupe pourrait obtenir son troisième prêt auprès de l'organisation, et ce prêt pourrait avoir un ID unique). Entrez ce numéro d'identification ici)
-  * Not_pictured: utilisez ce champ dans le cas où un emprunteur est listé à la rubrique 1 : Description n'apparaît pas dans la photo
-* La photo de l'emprunteur peut être envoyée à PA2 avec l’API.
-* Les tableaux de remboursement peuvent être envoyés dans plusieurs formats différents. Si vous pensez qu'un format différent de l'exemple ci-dessous conviendrait mieux à votre organisation, veuillez en informer Kiva et nous vous fournirons de plus amples informations.
-* Pour vérifier si le document JSON que vous avez créé est correct, vous pouvez utiliser un validateur JSON en ligne comme celui-ci : https://jsonlint.com/ .
+Avant que le prêt en question ne soit publié, PA2 effectuera tous les mêmes contrôles de validation que pour les prêts publiés sans l'API. Tous les messages d'erreur doivent être résolus avant que le prêt puisse être publié.
+
+Il n'y a pas de problème si l'API n'envoie pas d'informations pour certains champs nécessaires à la publication d'un prêt. Par exemple, tous les SIG ne stockent pas les champs spécifiques de Kiva tels que la description de l'emprunteur ou le secteur. Bien que ces champs soient nécessaires pour publier un prêt dans PA2, ils ne doivent pas être envoyés via l'API. Les informations relatives à ces champs peuvent être ajoutées manuellement après que le projet de prêt a été créé dans PA2. Notez que plus vous pouvez envoyer d'informations via l'API, plus le coordinateur Kiva gagnera du temps.
+
+Lorsque vous publiez un prêt collectif ou individuel, certains champs ne sont pas obligatoires. Si le prêt que vous publiez est un prêt individuel, et que vous soumettez des données spécifiques à un prêt collectif, PA2 vous donnera un message d'erreur et vous ne pourrez pas publier le prêt.
+
+Si un prêt individuel est comptabilisé, aucune des zones suivantes ne doit être incluse. Les champs suivants sont uniquement requis lors de la publication d'un prêt de groupe :
+* `group_name`: il s'agit du nom du groupe qui apparaîtra sur Kiva.org.
+* `internal_client_id`: est l'ID de chaque client représenté dans le groupe (par exemple, si un groupe compte trois membres, chacun d'entre eux peut avoir son propre ID de client à énumérer ici).
+* `internal_loan_id`: il s'agit de l'ID de chaque prêt individuel (par exemple, un membre du groupe pourrait obtenir son troisième prêt auprès de l'organisation, et ce prêt pourrait avoir un ID unique). Entrez ce numéro d'identification ici)
+* `not_pictured`: utilisez ce champ dans le cas où un emprunteur est listé à la rubrique 1 : Description n'apparaît pas dans la photo
+
+La photo de l'emprunteur peut être envoyée à PA2 avec l’API. Les tableaux de remboursement peuvent être envoyés dans plusieurs formats différents. Si vous pensez qu'un format différent de l'exemple ci-dessous conviendrait mieux à votre organisation, veuillez en informer Kiva et nous vous fournirons de plus amples informations. Pour vérifier si le document JSON que vous avez créé est correct, vous pouvez utiliser un validateur JSON en ligne comme celui-ci : https://jsonlint.com/ .
 
 ## Documentation technique
-* Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
-  * Environnement de test (Stage) https://partner-api-stage.dk1.kiva.org/swagger-ui/
-  * Production (à utiliser après les tests)  https://partner-api.k1.kiva.org/swagger-ui/
-
+Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
+* Environnement de test (Stage) https://partner-api-stage.dk1.kiva.org/swagger-ui/
+* Production (à utiliser après les tests)  https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/draftloans.md
+++ b/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/draftloans.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 ---
 
 # Utilisation de l'API pour publier des projets de prêts
-Nous recommandons à votre équipe technique de consulter le coordinateur Kiva de votre organisation afin de bien comprendre le processus de publication des projets de prêts Kiva. Pour ce faire, demandez à votre équipe technique d'examiner les points suivants:
+Nous recommandons à votre équipe technique de consulter le coordinateur Kiva de votre organisation afin de bien comprendre le processus de publication des projets de prêts Kiva. Pour ce faire, demandez à votre équipe technique d'examiner les points suivants :
 * [Cette vidéo](https://www.youtube.com/watch?v=9gScexv-yZo&amp;t=5s) explique en détail comment publier un prêt individuel.
 * [Cette vidéo](https://www.youtube.com/watch?v=KvKUScWF73M&amp;t=1s) explique en détail comment publier un prêt de groupe.
 * Consultez la section Nouveaux prêts pour plus d'informations, en particulier [l'étape 1 : Description - Prêts individuels](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360030919632) et [l'étape 1 : Description - Prêts de groupe](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360031260191).


### PR DESCRIPTION
[FPS-131](https://kiva.atlassian.net/browse/FPS-131): Added links into ES/FR, among other minor formatting/readability fixes.

Please check the PR comments for a link to the preview site generated by the GitHub action!

Current page URLs:
https://partners-docs.kiva.org/es/docs/overview/draftloans/
https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360051229991-Using-the-API-to-post-draft-loans

[FPS-131]: https://kiva.atlassian.net/browse/FPS-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ