### PR TITLE
FPS-133: Format 'fetch loans' page

### DIFF
--- a/portal/docs/overview/draftloans.md
+++ b/portal/docs/overview/draftloans.md
@@ -38,5 +38,5 @@ To check if the JSON document you created is correct, you can use an online JSON
 
 ## Technical documentation
 All of Kiva's technical documentation, including endpoints, can be found here:
-Test environment (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
-Production (to use after testing): https://partner-api.k1.kiva.org/swagger-ui/
+* Test environment (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
+* Production (to use after testing): https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/docs/overview/fetch_loans.md
+++ b/portal/docs/overview/fetch_loans.md
@@ -5,28 +5,30 @@ sidebar_position: 4
 # Using the API loans fetch endpoint
 
 ## Process
-A query for information is sent to PA2 via the API
-There are 4 search request parameters you can send: query, status, offset, and limit
+The loan data stored in PA2 can be fetched via the API. See our Swagger documentation for more details: [GET /v3/partner/{id}/loans](https://partner-api-stage.dk1.kiva.org/swagger-ui/#/partners/loansRouteUsingGET)
+
+There are 4 search request parameters you can send: `query`, `status`, `offset`, and `limit`.
 
 **Query**: can be any string that would be typed into the search bar in PA2 (e.g. name, Loan ID, Client ID or Kiva ID)
 
 **Status**: can be one of the following:
-refunded
-inactive
-inactive_expired
-fundRaising
-expired
-raised
-payingBack
-ended
-reviewed
-issue
-defaulted
+* `refunded`
+* `inactive`
+* `inactive_expired`
+* `fundRaising`
+* `expired`
+* `raised`
+* `payingBack`
+* `ended`
+* `reviewed`
+* `issue`
+* `defaulted`
 
-Offset & limit (“offset”, “limit”): works the same as any pagination, offset is how far into the list to go and limit is how many results to return. So to get the first 20 matches it would be offset=0, limit=20 and the next 20 would be offset=20 limit=20, etc.. The default is offset=0 and limit=20.
+**Offset, limit**: works the same as any pagination, offset is how far into the list to go and limit is how many results to return. So to get the first 20 matches it would be offset=0, limit=20 and the next 20 would be offset=20 limit=20, etc.. The default is offset=0 and limit=20.
 We don’t recommend requesting more than 300, because the volume of data can become very large and constrain server resources
 After making the request, the response from the API will be returned in JSON format
-Technical documentation
+
+## Technical documentation
 All of Kiva's technical documentation, including endpoints, can be found here:
 Test environment (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
 Production (to use after testing): https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/fetch_loans.md
+++ b/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/fetch_loans.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 ## Proceso
 
-* Se envía una consulta de información a PA2 a través de la API.
+* Se envía una consulta de información a PA2 a través de la API, [GET /v3/partner/{id}/loans](https://partner-api-stage.dk1.kiva.org/swagger-ui/#/partners/loansRouteUsingGET).
 * Hay 4 parámetros de solicitud de búsqueda que puede enviar: query, status, offset y limit
   * Query: puede ser cualquier línea que se escriba en la barra de búsqueda de PA2 (por ejemplo, nombre, ID de préstamo, ID de cliente o ID de Kiva) 
   * Status: puede ser uno de los siguientes:

--- a/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/fetch_loans.md
+++ b/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/fetch_loans.md
@@ -6,26 +6,26 @@ sidebar_position: 4
 
 
 ## Processus
-* Une requête d'information est envoyée à PA2 via l'API.
-  * Il existe 4 paramètres de demande de recherche que vous pouvez envoyer :: query, status, offset, and limit
-    * Query: peut être n'importe quelle ligne que vous tapez dans la barre de recherche PA2 (par exemple, le nom, l'ID du prêt, l'ID du client ou l'ID Kiva).
-    * Status:  peut être l'un des éléments suivants :
-      * refunded
-      * inactive
-      * inactive_expired
-      * fundRaising
-      * expired
-      * raised
-      * payingBack
-      * ended
-      * reviewed
-      * issue
-      * defaulted
-    * Offset & limit (“offset”, “limit”): fonctionne de la même manière que n'importe quelle pagination, offset est la distance à parcourir dans la liste et limit est le nombre de résultats à retourner. Ainsi, pour obtenir les 20 premières correspondances, il faudrait offset=0, limit=20 et les 20 suivantes seraient offset=20 limit=20, etc...  La valeur par défaut est offset=0 et limit=20.
-      * Nous ne recommandons pas de demander plus de 300, car le volume de données peut devenir très important et limiter les ressources du serveur.
-  * Une fois la demande effectuée, la réponse de l'API sera renvoyée au format JSON.
+* Une requête d'information est envoyée à PA2 via l'API, [GET /v3/partner/{id}/loans](https://partner-api-stage.dk1.kiva.org/swagger-ui/#/partners/loansRouteUsingGET).
+* Il existe 4 paramètres de demande de recherche que vous pouvez envoyer :: query, status, offset, and limit
+  * Query: peut être n'importe quelle ligne que vous tapez dans la barre de recherche PA2 (par exemple, le nom, l'ID du prêt, l'ID du client ou l'ID Kiva).
+  * Status:  peut être l'un des éléments suivants :
+    * refunded
+    * inactive
+    * inactive_expired
+    * fundRaising
+    * expired
+    * raised
+    * payingBack
+    * ended
+    * reviewed
+    * issue
+    * defaulted
+  * Offset & limit (“offset”, “limit”): fonctionne de la même manière que n'importe quelle pagination, offset est la distance à parcourir dans la liste et limit est le nombre de résultats à retourner. Ainsi, pour obtenir les 20 premières correspondances, il faudrait offset=0, limit=20 et les 20 suivantes seraient offset=20 limit=20, etc...  La valeur par défaut est offset=0 et limit=20.
+    * Nous ne recommandons pas de demander plus de 300, car le volume de données peut devenir très important et limiter les ressources du serveur.
+* Une fois la demande effectuée, la réponse de l'API sera renvoyée au format JSON.
 
 ## Documentation technique
 * Toute la documentation technique de Kiva, y compris les points de terminaison, peut être trouvée ici :
-* * Environnement de test (stage) :https://partner-api-stage.dk1.kiva.org/swagger-ui/
-* * Production (à utiliser après les tests) : https://partner-api.k1.kiva.org/swagger-ui/
+  * Environnement de test (stage) :https://partner-api-stage.dk1.kiva.org/swagger-ui/
+  * Production (à utiliser après les tests) : https://partner-api.k1.kiva.org/swagger-ui/


### PR DESCRIPTION
[FPS-133](https://kiva.atlassian.net/browse/FPS-131): Mostly formatting, but I added an explicit link to our GET documentation because I think it makes the content more clear. Also fixed a small page-to-page inconsistency in loan drafts.

Please check the PR comments for a link to the preview site generated by the GitHub action!

Current page URLs:
https://partners-docs.kiva.org/docs/overview/fetch_loans 
https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360051230151-Using-the-API-loans-fetch-endpoint

[FPS-133]: https://kiva.atlassian.net/browse/FPS-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ