### PR TITLE
FPS-134: Format 'using the API to post journals' page

### DIFF
--- a/portal/docs/overview/post_journals.md
+++ b/portal/docs/overview/post_journals.md
@@ -5,30 +5,28 @@ sidebar_position: 6
 # Using the API to post journals
 
 
-We recommend that your technical team consults with the Kiva Coordinator at your organization to fully understand Kiva's Repayment Reporting process. To do so, please have your technical team review the following:
-
-This video provides a thorough explanation on how to post journals
+We recommend that your technical team consults with the Kiva Coordinator at your organization to fully understand Kiva's Journaling process. Additionally, please have your technical team review the following:
 
 [![What is a journal?](https://img.youtube.com/vi/irTYtMImrAw/0.jpg)](https://www.youtube.com/watch?v=irTYtMImrAw)
 
+Visit the [Journals](https://kivapartnerhelpcenter.zendesk.com/hc/en-us/categories/360001945772-Journals) section for more information.
+
 ## Process
 
-Information for a new journal is sent from MIS to PA2 via the API
-The API will return a JSON response with a **confirm_url**.
+1. Information for a new journal is sent from MIS to PA2 via the API
+2. The API will return a JSON response with a `confirm_url`
+3. A person needs to go to the `confirm_url` and actually publish the journal draft
 
-A person needs to go to the **confirm_url** and actually publish the journal draft
-Additional information
+## Additional information
 
-For partners who use the two column format for repayment reporting and journaling, only the Loan ID (internal_loan_id) is needed. For partners that use the three column format, both the Loan ID (internal_loan_ID) and Client ID (internal_client_ID) are needed. 
+For partners who use the two column format for repayment reporting and journaling, only the Loan ID (`internal_loan_id`) is needed. For partners that use the three column format, both the Loan ID (`internal_loan_id`) and Client ID (`internal_client_id`) are needed. *This can be checked by going to _PA2 -> Account -> Profile -> CSV upload format*. 
 
-This can be checked by going to _PA2 -> Account -> Profile -> CSV upload format_. When testing the API connection for journals, please use information of a real client/borrower that has been posted to Kiva. 
-
-Do not use the same client information used to post a test loan draft as PA2 will not register this borrower as eligible for a journal update.
-
-To find an existing Kiva borrower, click on the “Journals” tab in PA2. This will take you to a report of all Kiva clients who are eligible for a journal. Select any of the client and loan IDs for these clients to send via the API.
+When testing the API connection for journals, please use information of a real client/borrower that has been posted to Kiva. Do not use the same client information used to post a test loan draft as PA2 will not register this borrower as eligible for a journal update.
+* To find an existing Kiva borrower, click on the “Journals” tab in PA2. This will take you to a report of all Kiva clients who are eligible for a journal. Select any of the client and loan IDs for these clients to send via the API.
 The content of the journal can be whatever you'd like it to be. 
+* The Kiva Coordinator is still required to log into PA2 to review journals before submitting them.
 
-The Kiva Coordinator is still required to log into PA2 to review journals before submitting them.
-Technical documentation
-
-All of Kiva's technical documentation, including endpoints, can be found [here](https://partner-api.k1.kiva.org/swagger-ui/):
+## Technical documentation
+All of Kiva's technical documentation, including endpoints, can be found here:
+* Test environment (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
+* Production (to use after testing): https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/post_journals.md
+++ b/portal/i18n/es/docusaurus-plugin-content-docs/current/overview/post_journals.md
@@ -4,24 +4,23 @@ sidebar_position: 6
 
 # Utilización de la API para publicar seguimientos
 
-
 Recomendamos que su equipo técnico consulte al coordinador Kiva en su organización para entender completamente el proceso de elaboración de seguimientos Para ello, solicite a su equipo técnico que revise lo siguiente:
 
 * [Este vídeo](https://www.youtube.com/watch?v=9KrerX22pQQ) proporciona una explicación exhaustiva sobre cómo publicar seguimientos.
 * Visita la sección “[Seguimientos](https://kivapartnerhelpcenter.zendesk.com/hc/es/categories/360001945772-Entradas-de-Seguimiento)” para más información.
 
 ## Proceso
-* La información de un nuevo seguimiento se envía desde el SIG a PA2 a través de la API.
-* La API devolverá una respuesta JSON con una confirm_url.
-* Una persona tiene que ir a la confirm_url y publicar el borrador del seguimiento.
+1. La información de un nuevo seguimiento se envía desde el SIG a PA2 a través de la API.
+2. La API devolverá una respuesta JSON con una confirm_url.
+3. Una persona tiene que ir a la confirm_url y publicar el borrador del seguimiento.
 
 ## Información adicional
-* Para los socios que utilizan el formato de dos columnas para los informes de reembolso y el registro de seguimientos, sólo se necesita el ID del préstamo (internal_loan_id). Para los socios que utilizan el formato de tres columnas, se necesita tanto el ID del préstamo (internal_loan_ID) como el ID del cliente (internal_client_ID). Esto se puede verificar yendo a PA2 -> Cuenta -> Perfil -> Formato de carga del CSV.
+* Para los socios que utilizan el formato de dos columnas para los informes de reembolso y el registro de seguimientos, sólo se necesita el ID del préstamo (`internal_loan_id`). Para los socios que utilizan el formato de tres columnas, se necesita tanto el ID del préstamo (`internal_loan_id`) como el ID del cliente (`internal_client_id`). *Esto se puede verificar yendo a PA2 -> Cuenta -> Perfil -> Formato de carga del CSV.*
 * Cuando pruebe la conexión de la API para los seguimientos, por favor, utilice la información de un cliente/prestatario real que haya sido publicado en Kiva. No utilice la misma información de cliente utilizada para publicar un borrador de préstamo de prueba, ya que PA2 no registrará a este prestatario como elegible para una actualización del seguimiento.
   * Para encontrar un prestatario de Kiva existente, haga clic en la pestaña "Seguimientos" en PA2. Esto le llevará a un informe de todos los clientes de Kiva que son elegibles para un seguimiento. Seleccione cualquiera de los ID de cliente y préstamo de estos clientes para enviarlos a través de la API.
   * El contenido del seguimiento puede ser el que usted desee. El coordinador de Kiva sigue teniendo que entrar en PA2 para revisar los seguimientos antes de enviarlos.
 
 ## Documentación técnica
 Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
-* Entorno de prueba (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
-* Producción (Para usar después de las pruebas): https://partner-api.k1.kiva.org/swagger-ui/
+ * Entorno de prueba (Stage): https://partner-api-stage.dk1.kiva.org/swagger-ui/
+ * Producción (Para usar después de las pruebas): https://partner-api.k1.kiva.org/swagger-ui/

--- a/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/post_journals.md
+++ b/portal/i18n/fr/docusaurus-plugin-content-docs/current/overview/post_journals.md
@@ -9,9 +9,9 @@ Nous recommandons à votre équipe technique de consulter le coordinateur Kiva d
 * [Consultez la section Nouveaux](https://kivapartnerhelpcenter.zendesk.com/hc/fr/categories/360001759932-Nouveaux-Credits) prêts pour plus d'informations, en particulier [l'étape 1 : Description - Prêts individuels](https://kivapartnerhelpcenter.zendesk.com/hc/fr/articles/360030919632-%C3%89tape-1-Description-Cr%C3%A9dits-individuels)  et l'étape [1 : Description - Prêts de groupe](https://kivapartnerhelpcenter.zendesk.com/hc/fr/articles/360031260191-%C3%89tape-1-Description-Cr%C3%A9dits-de-Groupe).
  
 ## Processus
-* Les nouvelles informations sur les prêts sont envoyées du SIG à PA2 via l'API.
-* Un projet de prêt est automatiquement créé. Les projets peuvent être consultés en cliquant sur le lien " Brouillons " dans la section " Prêts " de la page d'accueil de PA2.
-* Utilisation du point de terminaison de récupération des prêts de l'API.
+1. Les nouvelles informations sur les prêts sont envoyées du SIG à PA2 via l'API.
+2. Un projet de prêt est automatiquement créé. Les projets peuvent être consultés en cliquant sur le lien " Brouillons " dans la section " Prêts " de la page d'accueil de PA2.
+3. Utilisation du point de terminaison de récupération des prêts de l'API.
 
 ## Informations complémentaires
 * Avant que le prêt en question ne soit publié, PA2 effectuera tous les mêmes contrôles de validation que pour les prêts publiés sans l'API. Tous les messages d'erreur doivent être résolus avant que le prêt puisse être publié.
@@ -27,7 +27,7 @@ Nous recommandons à votre équipe technique de consulter le coordinateur Kiva d
 * Pour vérifier si le document JSON que vous avez créé est correct, vous pouvez utiliser un validateur JSON en ligne comme celui-ci : https://jsonlint.com/ .
 
 ## Documentation technique
-* Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
-  * Environnement de test (Stage) https://partner-api-stage.dk1.kiva.org/swagger-ui/
-  * Production (à utiliser après les tests)  https://partner-api.k1.kiva.org/swagger-ui/
+Toda la documentación técnica de Kiva, incluidos los puntos finales, puede encontrarse aquí:
+ * Environnement de test (Stage) https://partner-api-stage.dk1.kiva.org/swagger-ui/
+ * Production (à utiliser après les tests)  https://partner-api.k1.kiva.org/swagger-ui/
 


### PR DESCRIPTION
[FPS-134](https://kiva.atlassian.net/browse/FPS-134): Mostly formatting with some minor editorial updates.

Please check the PR comments for a link to the preview site generated by the GitHub action!

I'm still looking for the French content for "Additional information," it looks like the content here is all from the Loan Draft page... will include in a separate PR if I don't find it easily.

Current page URLs:
https://kivapartnerhelpcenter.zendesk.com/hc/en-us/articles/360050743392-Using-the-API-to-post-journals
https://partners-docs.kiva.org/docs/overview/post_journals

[FPS-134]: https://kiva.atlassian.net/browse/FPS-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ